### PR TITLE
Remove use of deprecated APIs

### DIFF
--- a/websocketpp/common/memory.hpp
+++ b/websocketpp/common/memory.hpp
@@ -65,7 +65,6 @@ namespace lib {
 #ifdef _WEBSOCKETPP_CPP11_MEMORY_
     using std::shared_ptr;
     using std::weak_ptr;
-    using std::auto_ptr;
     using std::enable_shared_from_this;
     using std::static_pointer_cast;
     using std::make_shared;

--- a/websocketpp/utilities.hpp
+++ b/websocketpp/utilities.hpp
@@ -72,10 +72,10 @@ private:
  * Based on code from
  * http://stackoverflow.com/questions/3152241/case-insensitive-stdstring-find
  */
-struct ci_less : std::binary_function<std::string, std::string, bool> {
+struct ci_less : std::function<bool(std::string, std::string)> {
     // case-independent (ci) compare_less binary function
     struct nocase_compare
-      : public std::binary_function<unsigned char,unsigned char,bool>
+      : public std::function<bool(unsigned char,unsigned char)>
     {
         bool operator() (unsigned char const & c1, unsigned char const & c2) const {
             return tolower (c1) < tolower (c2);

--- a/websocketpp/utilities.hpp
+++ b/websocketpp/utilities.hpp
@@ -72,11 +72,9 @@ private:
  * Based on code from
  * http://stackoverflow.com/questions/3152241/case-insensitive-stdstring-find
  */
-struct ci_less : std::function<bool(std::string, std::string)> {
+struct ci_less {
     // case-independent (ci) compare_less binary function
-    struct nocase_compare
-      : public std::function<bool(unsigned char,unsigned char)>
-    {
+    struct nocase_compare {
         bool operator() (unsigned char const & c1, unsigned char const & c2) const {
             return tolower (c1) < tolower (c2);
         }


### PR DESCRIPTION
Remove use of `std::auto_ptr` and `std::binary_function` which was deprecated in C++11 and then removed in C++17.

These changes also seem to reflect upstream changes.

* `std::auto_ptr` change: https://github.com/zaphoyd/websocketpp/blob/master/websocketpp/common/memory.hpp#L65
* `std::binary_function` changes: https://github.com/zaphoyd/websocketpp/blob/master/websocketpp/utilities.hpp#L75

Also see this commit: https://github.com/zaphoyd/websocketpp/commit/cb3d7de91fdfc7f9c0c824c2911873078f6ce89a
